### PR TITLE
Feat/responsive

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "grommet-icons": "^4.1.0",
     "moment": "^2.22.2",
     "prop-types": "^15.6.2",
+    "query-string": "^6.2.0",
     "ramda": "^0.25.0",
     "react": "^16.5.2",
     "react-apollo": "^2.1.11",

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import Profile from "./screens/Profile";
 import client from "./config/apolloConfig";
 import registerServiceWorker from "./registerServiceWorker";
 import { createGlobalStyle } from "styled-components";
+import theme from "./theme";
 
 const GlobalStyle = createGlobalStyle`
   * {
@@ -17,7 +18,7 @@ const GlobalStyle = createGlobalStyle`
 `;
 
 ReactDOM.render(
-  <Grommet>
+  <Grommet theme={theme} full>
     <ApolloProvider client={client}>
       <GlobalStyle />
       <Profile />

--- a/src/screens/Profile/Main.js
+++ b/src/screens/Profile/Main.js
@@ -8,7 +8,7 @@ import User from "./components/User";
 import { getDirection } from "./utils/helpers";
 
 export default class Profile extends Component {
-  state = { user: "" };
+  state = { user: window.location.pathname.replace("/", "") };
 
   searchProfile = user => this.setState({ user });
 

--- a/src/screens/Profile/components/RepositoryInfo/RepositoryInfo.js
+++ b/src/screens/Profile/components/RepositoryInfo/RepositoryInfo.js
@@ -136,14 +136,14 @@ const RepositoryInfo = ({
               >
                 <Statistics
                   id="by-repository"
-                  title="Commits per Repo Top 10"
+                  title="Stars per Repo Top 10"
                   data={createData(dataSet, "repositories", "stars")}
                   configuration={createConfiguration(login, "bottom")}
                   size="large"
                 />
                 <Statistics
                   id="by-repository"
-                  title="Stars per Repo Top 10"
+                  title="Commits per Repo Top 10"
                   data={createData(dataSet, "repositories", "commits")}
                   configuration={createConfiguration(login, "bottom")}
                   size="large"

--- a/src/screens/Profile/components/RepositoryInfo/RepositoryInfo.js
+++ b/src/screens/Profile/components/RepositoryInfo/RepositoryInfo.js
@@ -81,13 +81,8 @@ const RepositoryInfo = ({
       return (
         <ResponsiveContext.Consumer>
           {size => (
-            <Box responsive align="center" gap="medium" width="full">
-              <Box
-                responsive
-                direction={getDirection(size)}
-                justify="center"
-                wrap
-              >
+            <Box align="center" gap="medium" width="full">
+              <Box direction="row" justify="center" wrap>
                 <ActivityBox
                   icon={renderIcon({
                     Icon: GoRepo,

--- a/src/screens/Profile/components/Sidebar/Sidebar.js
+++ b/src/screens/Profile/components/Sidebar/Sidebar.js
@@ -24,10 +24,6 @@ const Avatar = styled(Image)`
   width: 15rem;
 `;
 
-const HeadingName = styled(Heading)`
-  margin-top: 0;
-`;
-
 const Sidebar = ({
   avatar,
   bio,
@@ -42,15 +38,14 @@ const Sidebar = ({
   <ResponsiveContext.Consumer>
     {size => (
       <Wrapper>
-        <Box responsive justify="center" align="center" gap="small">
+        <Box justify="center" align="center" gap="small">
           <Avatar src={avatar} />
-          <HeadingName level={2} size="medium" responsive>
+          <Heading level={2} size="medium" margin={{ top: 0 }}>
             {name}
-          </HeadingName>
+          </Heading>
           <Text textAlign="center">{bio}</Text>
         </Box>
         <Box
-          responsive
           direction={getDirection(size)}
           justify="center"
           align="center"
@@ -69,7 +64,7 @@ const Sidebar = ({
             quantity={following}
           />
         </Box>
-        <Box responsive gap="small">
+        <Box gap="small">
           <StatsBox
             icon={renderIcon({ Icon: GoClock, size: "3rem" })}
             title={`Joined Github ${moment(createdAt).fromNow()}`}

--- a/src/screens/Profile/components/Sidebar/Sidebar.js
+++ b/src/screens/Profile/components/Sidebar/Sidebar.js
@@ -8,9 +8,6 @@ import styled from "styled-components";
 
 import Follow from "./components/Follow";
 import StatsBox from "./components/StatsBox";
-import { getDirection } from "../../utils/helpers";
-
-const renderIcon = ({ Icon, ...props }) => <Icon size="2rem" {...props} />;
 
 const Wrapper = styled(Box)`
   background-color: #fff;
@@ -43,44 +40,44 @@ const Sidebar = ({
           <Heading level={2} size="medium" margin={{ top: 0 }}>
             {name}
           </Heading>
-          <Text textAlign="center">{bio}</Text>
+          {bio && (
+            <Text textAlign="center" margin="medium">
+              {bio}
+            </Text>
+          )}
         </Box>
         <Box
-          direction={getDirection(size)}
+          direction="row"
           justify="center"
           align="center"
           gap="large"
           margin="medium"
         >
           <Follow
-            icon={renderIcon({ Icon: FaUserCheck })}
+            icon={<FaUserCheck size="2rem" />}
             title="Followers"
             quantity={followers}
           />
 
           <Follow
-            icon={renderIcon({ Icon: FaUserPlus })}
+            icon={<FaUserPlus size="2rem" />}
             title="Following"
             quantity={following}
           />
         </Box>
-        <Box gap="small">
+        {console.log(size)}
+        <Box gap="small" direction="row" wrap>
           <StatsBox
-            icon={renderIcon({ Icon: GoClock, size: "3rem" })}
+            icon={<GoClock size="2.5rem" />}
             title={`Joined Github ${moment(createdAt).fromNow()}`}
           />
-          <StatsBox
-            icon={renderIcon({ Icon: GoMail, size: "3rem" })}
-            title={email}
-          />
-          <StatsBox
-            icon={renderIcon({ Icon: GoCode, size: "3rem" })}
-            title={company}
-          />
-          <StatsBox
-            icon={renderIcon({ Icon: GoLocation, size: "3rem" })}
-            title={location}
-          />
+          {email && <StatsBox icon={<GoMail size="2.5rem" />} title={email} />}
+          {company && (
+            <StatsBox icon={<GoCode size="2.5rem" />} title={company} />
+          )}
+          {location && (
+            <StatsBox icon={<GoLocation size="2.5rem" />} title={location} />
+          )}
         </Box>
       </Wrapper>
     )}
@@ -89,14 +86,14 @@ const Sidebar = ({
 
 Sidebar.propTypes = {
   avatar: string.isRequired,
-  bio: string,
-  company: string,
-  createdAt: string,
-  email: string,
   followers: number.isRequired,
   following: number.isRequired,
-  location: string.isRequired,
-  name: string.isRequired
+  name: string.isRequired,
+  createdAt: string.isRequired,
+  location: string,
+  bio: string,
+  company: string,
+  email: string
 };
 
 export default Sidebar;

--- a/src/screens/Profile/components/Sidebar/components/Follow/Follow.js
+++ b/src/screens/Profile/components/Sidebar/components/Follow/Follow.js
@@ -1,26 +1,15 @@
 import React from "react";
 import { element, number, string } from "prop-types";
-import { Box, Text, ResponsiveContext } from "grommet";
-
-import { getDirection } from "../../../../utils/helpers";
+import { Box, Text } from "grommet";
 
 const Follow = ({ icon, title, quantity }) => (
-  <ResponsiveContext.Consumer>
-    {size => (
-      <Box
-        responsive
-        direction={getDirection(size)}
-        align="center"
-        gap="medium"
-      >
-        <Text>{icon}</Text>
-        <Box responsive align="center">
-          <Text>{quantity}</Text>
-          <Text>{title}</Text>
-        </Box>
-      </Box>
-    )}
-  </ResponsiveContext.Consumer>
+  <Box align="center" gap="medium" direction="row">
+    <Text>{icon}</Text>
+    <Box align="center">
+      <Text>{quantity}</Text>
+      <Text>{title}</Text>
+    </Box>
+  </Box>
 );
 
 Follow.defaultProps = {
@@ -29,8 +18,8 @@ Follow.defaultProps = {
 
 Follow.propTypes = {
   icon: element.isRequired,
-  quantity: number,
-  title: string.isRequired
+  title: string.isRequired,
+  quantity: number
 };
 
 export default Follow;

--- a/src/screens/Profile/components/Sidebar/components/StatsBox/StatsBox.js
+++ b/src/screens/Profile/components/Sidebar/components/StatsBox/StatsBox.js
@@ -3,8 +3,8 @@ import { element, string } from "prop-types";
 import { Box, Text } from "grommet";
 
 const StatsBox = ({ icon, title }) => (
-  <Box responsive direction="row" align="center" gap="small">
-    <Box responsive>{icon}</Box>
+  <Box direction="row" align="center" gap="small" basis="300px">
+    <Box>{icon}</Box>
     <Text>{title}</Text>
   </Box>
 );

--- a/src/screens/Profile/utils/helpers.js
+++ b/src/screens/Profile/utils/helpers.js
@@ -1,6 +1,7 @@
-import { equals, filter, gt, isNil, not, path, pathOr, subtract } from "ramda";
+import { filter, gt, isNil, not, path, pathOr, subtract } from "ramda";
 
-const getDirection = size => (equals(size, "small") ? "column" : "row");
+const getDirection = size =>
+  ["xsmall", "small"].includes(size) ? "column" : "row";
 
 const removeEmpties = (data = []) => filter(value => value !== 0, data);
 

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,0 +1,21 @@
+import { deepMerge } from "grommet/utils";
+import { grommet } from "grommet/themes";
+
+const theme = deepMerge(grommet, {
+  global: {
+    breakpoints: {
+      xsmall: {
+        value: 500
+      },
+      small: {
+        value: 900
+      },
+      medium: undefined,
+      middle: {
+        value: 3000
+      }
+    }
+  }
+});
+
+export default theme;

--- a/src/theme.js
+++ b/src/theme.js
@@ -8,7 +8,7 @@ const theme = deepMerge(grommet, {
         value: 500
       },
       small: {
-        value: 900
+        value: 800
       },
       medium: undefined,
       middle: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8781,6 +8781,14 @@ qs@6.5.2, qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
+query-string@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.2.0.tgz#468edeb542b7e0538f9f9b1aeb26f034f19c86e1"
+  integrity sha512-5wupExkIt8RYL4h/FE+WTg3JHk62e6fFPWtAZA9J5IWK1PfTfKkMS93HBUHcFpeYi9KsY5pFbh+ldvEyaz5MyA==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    strict-uri-encode "^2.0.0"
+
 querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -10045,6 +10053,11 @@ stream-shift@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.0.tgz#d5c752825e5367e786f78e18e445ea223a155952"
   integrity sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
+  integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
 string-length@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
First of all, nice grommet implementation with styled-components! The code is nice and clear :clap:

## Changes

- Add routing for user fetching: I found it was super annoying every time I make a change to type my user name inside the search bar. Now I'm reading the user from the URL, which is quite handy :) Example that works: `http://localhost:3000/EmaSuriano` and in case someone doesn't provide anything the behavior it's the same.
- Add new breakpoints to the theme: Now we have a new size called `xsmall` which is quite handy in case we want to apply new rules when the screen is super tiny. I think I didn't use at last, but it's there in case we want it :D  Also I change the value for the breakpoint of `small`, it was 900 by default and now it's 800.
- Change responsiveness of Sidebar: making some changes inside the components, removing stuff and adding new props. The thing I like how it's right now is the `StatsBox` that can be grouped into two columns now because of `wrap`, and when we are in mobile and have enough width we can show 2 per line. And when we move to `xsmall` we have again one column as before. In Desktop mode it's one column as before too.

## Before & After Screenshots

**BEFORE**:
<img width="1440" alt="screenshot 2019-01-09 at 10 16 29" src="https://user-images.githubusercontent.com/3399429/50893879-3bf65400-1402-11e9-8638-cfa6aafc6d6e.png">

**AFTER**:
<img width="1440" alt="screenshot 2019-01-09 at 11 19 42" src="https://user-images.githubusercontent.com/3399429/50893881-3bf65400-1402-11e9-8f8f-6c4fbe58c52f.png">
![image](https://user-images.githubusercontent.com/3399429/50893944-5f210380-1402-11e9-858b-b72ca6d6cf3b.png)

Then I have some comments on the code I found:
- Always try to avoid creating custom styled-components and use the Grommet props, which cover the most general cases for layout. The example I found:

``` javascript

const HeadingName = styled(Heading)`
  margin-top: 0;
`;

// Instead of that, you can set the margin inline for the component

<Heading margin={{top: 0}} />
```

- Remember that the responsive prop is by default `true` in Grommet, so it's not needed for you to send it to all the components. I removed it in some of the components while I was looking, but not ALL. 


