### PR TITLE
Fix/react reveal ssr

### DIFF
--- a/components/Header/Header.js
+++ b/components/Header/Header.js
@@ -1,6 +1,6 @@
 import React, { Component, createRef } from 'react';
 import { func, string } from 'prop-types';
-import { Box, ResponsiveContext, Text, TextInput } from 'grommet';
+import { Box, Button, Text, ResponsiveContext, TextInput } from 'grommet';
 import { Search } from 'grommet-icons';
 import styled from 'styled-components';
 import Slide from 'react-reveal/Slide';
@@ -50,11 +50,11 @@ export default class Header extends Component {
               pad={{ horizontal: 'medium', vertical: 'small' }}
               gap="medium"
             >
-              <Box>
+              <Button href="/">
                 <PageTitle level={1} size="large" weight="bold">
                   Github Reporter
                 </PageTitle>
-              </Box>
+              </Button>
               <Box direction="row" basis="full" align="center" gap="small">
                 <Box
                   basis="full"

--- a/components/Header/Header.js
+++ b/components/Header/Header.js
@@ -40,7 +40,7 @@ export default class Header extends Component {
     const { query } = this.state;
 
     return (
-      <Slide top>
+      <Slide top ssrFadeout>
         <ResponsiveContext.Consumer>
           {size => (
             <Box

--- a/components/RepositoryInfo/RepositoryInfo.js
+++ b/components/RepositoryInfo/RepositoryInfo.js
@@ -5,6 +5,7 @@ import { Query } from 'react-apollo';
 import { PulseLoader } from 'react-spinners';
 import { GoPin, GoRepo, GoStar } from 'react-icons/go';
 import { Box, ResponsiveContext } from 'grommet';
+import Error from 'next/error';
 import Fade from 'react-reveal/Fade';
 
 import { GET_REPOSITORIES_INFORMATION } from './query';
@@ -36,11 +37,11 @@ const RepositoryInfo = ({ id, login, pinnedRepositories, repositories, starredRe
         return (
           <PulseLoader
             className="spinner"
-            loading={true}
             color="#90C3FF"
             sizeUnit="rem"
             size={5}
             margin="1rem"
+            loading
           />
         );
 

--- a/components/RepositoryInfo/RepositoryInfo.js
+++ b/components/RepositoryInfo/RepositoryInfo.js
@@ -77,7 +77,7 @@ const RepositoryInfo = ({ id, login, pinnedRepositories, repositories, starredRe
         <ResponsiveContext.Consumer>
           {size => (
             <Box align="center" jutify="center" gap="medium" width="full">
-              <Fade big>
+              <Fade big ssrFadeout>
                 <Box direction={getDirection(size)} justify="center" wrap>
                   <ActivityBox
                     icon={renderIcon({

--- a/components/Sidebar/Sidebar.js
+++ b/components/Sidebar/Sidebar.js
@@ -33,7 +33,7 @@ const Sidebar = ({
   location,
   name,
 }) => (
-  <Fade left>
+  <Fade left ssrFadeout>
     <Wrapper>
       <Box justify="center" align="center" gap="small">
         <Avatar src={avatar} />

--- a/lib/init-apollo.js
+++ b/lib/init-apollo.js
@@ -31,12 +31,6 @@ function create(initialState) {
 }
 
 export default function initApollo(initialState) {
-  // Make sure to create a new client for every server-side request so that data
-  // isn't shared between connections (which would be bad)
-  if (!process.browser) {
-    return create(initialState);
-  }
-
   // Reuse client on the client-side
   if (!apolloClient) {
     apolloClient = create(initialState);


### PR DESCRIPTION
## What is this pr about? 🤔
Improving the SSR of the application.

## Changes 🧳
- [x] Add cache for all the connection, in this case, I want to always cache the parameters inside the url.
- [x] I add the prop of ssrFadeout for all the react-reveal component, this is to avoid running the animation on the server.

Just to let you know, there is an issue of rendering the application twice the first time which is super annoying. I started looking for a solution and found [this issue](https://github.com/zeit/next.js/issues/5050) in Github which says that it's expected to be like that because of the `getDataFromTree`. So I really don't know how to fix it, if you want to also look a solution be my guest 😄 